### PR TITLE
fixed spent outpoint serialisation for spent index/filter

### DIFF
--- a/src/core/cfilter.go
+++ b/src/core/cfilter.go
@@ -129,6 +129,6 @@ func SerialiseToOutpoint(utxo types.UTXO) ([]byte, error) {
 	// err is always nil
 	buf.Write(common.ReverseBytes(txidBytes))
 
-	binary.Write(&buf, binary.LittleEndian, utxo.Value)
+	binary.Write(&buf, binary.LittleEndian, utxo.Vout)
 	return buf.Bytes(), err
 }

--- a/src/server/middleware.go
+++ b/src/server/middleware.go
@@ -32,7 +32,7 @@ func FetchHeaderInvMiddleware(c *gin.Context) {
 		c.Abort()
 		return
 	}
-	common.InfoLogger.Printf("%v\n", headerInv)
+
 	// Store headerInv in Gin context
 	c.Set("headerInv", headerInv)
 	c.Next()


### PR DESCRIPTION
removed unnecessary logging