### PR TITLE
bug fix: fix byte order for block hash

### DIFF
--- a/src/core/spentutxos.go
+++ b/src/core/spentutxos.go
@@ -28,7 +28,7 @@ func BuildSpentUTXOIndex(utxos []types.UTXO, block *types.Block) (types.SpentOut
 			return types.SpentOutpointsIndex{}, err
 		}
 
-		hashedOutpoint := sha256.Sum256(append(outpoint, blockHashBytes...))
+		hashedOutpoint := sha256.Sum256(append(outpoint, common.ReverseBytes(blockHashBytes)...))
 		spentOutpointsIndex.Data = append(spentOutpointsIndex.Data, [types.LenOutpointHashShort]byte(hashedOutpoint[:]))
 	}
 


### PR DESCRIPTION
Just like the txid, the block hash bytes should be reversed after they are read from a hex string.