### PR TITLE
Fix byte order for block hash

### DIFF
--- a/src/core/spentutxos.go
+++ b/src/core/spentutxos.go
@@ -15,6 +15,9 @@ func BuildSpentUTXOIndex(utxos []types.UTXO, block *types.Block) (types.SpentOut
 		return types.SpentOutpointsIndex{}, err
 	}
 
+	// reverse byte order to make little endian
+	blockHashBytes = common.ReverseBytes(blockHashBytes)
+
 	spentOutpointsIndex := types.SpentOutpointsIndex{
 		BlockHash:   block.Hash,
 		BlockHeight: block.Height,


### PR DESCRIPTION
Although the previous fix was incorrect, the byte order should still be reversed.