### PR TITLE
Don't return error on zero-amount spendable output

### DIFF
--- a/src/common/types/utxo.go
+++ b/src/common/types/utxo.go
@@ -159,9 +159,14 @@ func FindBiggestRemainingUTXO(utxoSpent UTXO, utxos []UTXO) (*uint64, error) {
 
 	if spentIsMax {
 		if valueMax == 0 {
-			common.ErrorLogger.Printf("%+v", utxoSpent)
-			common.ErrorLogger.Printf("%+v", utxos)
-			return nil, errors.New("valueMax was 0. this should not happen")
+			// The max unspent value of this transaction is 0.
+			// This can happen for some non-standard transactions, for example:
+			// 6dd08f9cec8fe67ecea970e1ac0c4963950a0900628fccfb29493be02efaf828
+			common.WarningLogger.Printf("%+v", utxoSpent)
+			common.WarningLogger.Printf("%+v", utxos)
+
+			// Even though this output is technically spendable, we skip it by returning nil
+			return nil, nil
 		}
 		// If the spent UTXO was the largest, return the max value among the remaining UTXOs.
 		return &valueMax, nil

--- a/src/db/dblevel/tweak.go
+++ b/src/db/dblevel/tweak.go
@@ -184,18 +184,19 @@ func DustOverwriteRoutine() error {
 			common.ErrorLogger.Println(err)
 			return err
 		}
-		// todo highestValue might be nil here
-		tweak.HighestValue = *highestValue
-		tweaksForBatchInsert = append(tweaksForBatchInsert, tweak)
-		if counter%2_500 == 0 {
-			common.InfoLogger.Println("Inserting for", counter)
-			// we use insert instead of overwrite because we already have all the information ready
-			err = InsertBatchTweaks(tweaksForBatchInsert)
-			if err != nil {
-				common.ErrorLogger.Println(err)
-				return err
+		if highestValue != nil {
+			tweak.HighestValue = *highestValue
+			tweaksForBatchInsert = append(tweaksForBatchInsert, tweak)
+			if counter%2_500 == 0 {
+				common.InfoLogger.Println("Inserting for", counter)
+				// we use insert instead of overwrite because we already have all the information ready
+				err = InsertBatchTweaks(tweaksForBatchInsert)
+				if err != nil {
+					common.ErrorLogger.Println(err)
+					return err
+				}
+				tweaksForBatchInsert = []types.Tweak{}
 			}
-			tweaksForBatchInsert = []types.Tweak{}
 		}
 	}
 


### PR DESCRIPTION
Skip the output instead.

Note: I don't know blindbit well enough to tell if passing `nil` here is completely fine. From the function itself it looks like it's possible that `nil, nil` gets returned, so I used it here for my fix too.

Closes #33 