### PR TITLE
blindbit.toml.example: reorder user/pass, fix signet rpc port

### DIFF
--- a/blindbit.example.toml
+++ b/blindbit.example.toml
@@ -7,16 +7,16 @@ host = "127.0.0.1:8000"
 chain = "signet"
 
 # default: http://127.0.0.1:8332
-rpc_endpoint = "http://127.0.0.1:18443"
+rpc_endpoint = "http://127.0.0.1:38332"
 
 # required, unless rpc_user and rpc_pass are set
 cookie_path = ""
 
 # required, unless cookie_path is set
-rpc_pass = "your-rpc-password"
+rpc_user = "your-rpc-user"
 
 # required, unless cookie_path is set
-rpc_user = "your-rpc-user"
+rpc_pass = "your-rpc-password"
 
 # required (has to be >= 1)
 sync_start_height = 1


### PR DESCRIPTION
Some small improvements in the config file that I tripped over while getting to run blindbit-oracle for the first time: reorder entries so that user comes before password, adapt the RPC port to match the signet chain setting (the current one is for regtest).